### PR TITLE
[DOCS] 도커파일 수정

### DIFF
--- a/src/frontend/visti/Dockerfile
+++ b/src/frontend/visti/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 COPY ./package*.json ./
 
-RUN npm install --force
+RUN npm install
 
 COPY . .
 


### PR DESCRIPTION

## Reason For PR?
- [#10] feature 병합

## Summary
프론트엔드 visti 도커파일 npm install --force 에서 force 제거
- 로컬 vscode에서 테스트 할 때 
npm WARN using --force Recommended protections disabled. 라는 문구가 있어 로컬에서도 npm install이 안되는 것을 확인, 브랜치에서 force 설정을 제외했을 시 정상 배포 되는 것을 확인하였습니다.