### PR TITLE
[FEAT] 카카오 계정 회원탈퇴 기능 구현

### DIFF
--- a/src/mobile/vistiandroid/buildSrc/src/main/java/Version.kt
+++ b/src/mobile/vistiandroid/buildSrc/src/main/java/Version.kt
@@ -2,8 +2,8 @@ object Versions {
     const val COMPILE_SDK_VERSION = 33
     const val MIN_SDK_VERSION = 24
     const val TARGET_SDK_VERSION = 33
-    const val APP_VERSION_CODE = 1
-    const val APP_VERSION_NAME = "1.0"
+    const val APP_VERSION_CODE = 2
+    const val APP_VERSION_NAME = "1.0.1"
 
     const val ANDROID_GRADLE_PLUGIN = "7.0.4"
     const val KOTLIN_VERSION = "1.6.10"

--- a/src/mobile/vistiandroid/data/src/main/java/com/ssafy/data/dto/UserTokenDto.kt
+++ b/src/mobile/vistiandroid/data/src/main/java/com/ssafy/data/dto/UserTokenDto.kt
@@ -18,3 +18,9 @@ data class UserBodyDto(
     val email: String,
     val password: String
 )
+
+data class DeleteUserResponse(
+    val detail: String,
+    val message: String,
+    val statusCode: Int
+)

--- a/src/mobile/vistiandroid/data/src/main/java/com/ssafy/data/remote/VistiApi.kt
+++ b/src/mobile/vistiandroid/data/src/main/java/com/ssafy/data/remote/VistiApi.kt
@@ -1,5 +1,6 @@
 package com.ssafy.data.remote
 
+import com.ssafy.data.dto.DeleteUserResponse
 import com.ssafy.data.dto.HomeStoryBoxResponse
 import com.ssafy.data.dto.HomeStoryResponse
 import com.ssafy.data.dto.MemberResponse
@@ -55,4 +56,7 @@ interface VistiApi {
 
     @POST("/api/story-box/enter")
     suspend fun enterStoryBox(@Body storyBoxId: String)
+
+    @POST("/api/member/withdraw")
+    suspend fun deleteUser(): DeleteUserResponse
 }

--- a/src/mobile/vistiandroid/data/src/main/java/com/ssafy/data/repository/UserRepositoryImpl.kt
+++ b/src/mobile/vistiandroid/data/src/main/java/com/ssafy/data/repository/UserRepositoryImpl.kt
@@ -27,4 +27,8 @@ class UserRepositoryImpl @Inject constructor(
         preferenceDataSource.putString(REFRESH_TOKEN, response.refreshToken)
         return response
     }
+
+    override suspend fun deleteUser(): String {
+        return api.deleteUser().detail
+    }
 }

--- a/src/mobile/vistiandroid/domain/src/main/java/com/ssafy/domain/repository/UserRepository.kt
+++ b/src/mobile/vistiandroid/domain/src/main/java/com/ssafy/domain/repository/UserRepository.kt
@@ -7,4 +7,5 @@ interface UserRepository {
     suspend fun signIn(userBody: UserBody): UserToken
     suspend fun socialSignUp(provider: String, accessToken: String): UserToken
 
+    suspend fun deleteUser(): String
 }

--- a/src/mobile/vistiandroid/domain/src/main/java/com/ssafy/domain/usecase/account/DeleteUserUseCase.kt
+++ b/src/mobile/vistiandroid/domain/src/main/java/com/ssafy/domain/usecase/account/DeleteUserUseCase.kt
@@ -1,0 +1,27 @@
+package com.ssafy.domain.usecase.account
+
+import com.ssafy.domain.model.Resource
+import com.ssafy.domain.repository.UserRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+
+class DeleteUserUseCase @Inject constructor(
+    private val repository: UserRepository
+) {
+    operator fun invoke(): Flow<Resource<String>> = flow {
+        try {
+            emit(Resource.Loading())
+            val deleteUserResponse = repository.deleteUser()
+            emit(Resource.Success(deleteUserResponse))
+        } catch (e: IOException) {
+            emit(Resource.Error("Failed to connect to server \uD83D\uDE22"))
+        } catch (e: HttpException) {
+            emit(Resource.Error(e.localizedMessage ?: "Error occurred"))
+        } catch (e: Exception) {
+            emit(Resource.Error(e.localizedMessage ?: "Error occurred"))
+        }
+    }
+}

--- a/src/mobile/vistiandroid/presentation/src/main/java/com/ssafy/presentation/ui/setting/UserAccountScreen.kt
+++ b/src/mobile/vistiandroid/presentation/src/main/java/com/ssafy/presentation/ui/setting/UserAccountScreen.kt
@@ -1,5 +1,6 @@
 package com.ssafy.presentation.ui.setting
 
+import android.util.Log
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -10,6 +11,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import com.kakao.sdk.user.UserApiClient
 import com.ssafy.presentation.SignInNav
 import com.ssafy.presentation.ui.common.VistiDialog
 import com.ssafy.presentation.ui.setting.component.BackToolbar
@@ -49,9 +51,9 @@ fun UserAccountScreen(
             DetailSettingButton("계정 로그아웃", PrimaryColor) {
                 logOutState.value = true
             }
-//            DetailSettingButton("계정 회원탈퇴", PrimaryColor) {
-//                signOutState.value = true
-//            }
+            DetailSettingButton("계정 회원탈퇴", PrimaryColor) {
+                signOutState.value = true
+            }
 
             val isDarkTheme = isSystemInDarkTheme()
 
@@ -77,7 +79,30 @@ fun UserAccountScreen(
             if (signOutState.value) {
                 VistiDialog(
                     onDismissRequest = { signOutState.value = false },
-                    onConfirmation = { signOutState.value = false },
+                    onConfirmation = {
+                        signOutState.value = false
+
+                        UserApiClient.instance.unlink { error ->
+                            if (error != null) {
+                                // 에러가 발생한 경우 처리
+                                Log.d("ohhuiju", "회원 탈퇴 실패: $error")
+                            } else {
+                                // 회원 탈퇴가 성공한 경우 처리
+                                Log.d("ohhuiju","카카오 소셜 로그인으로 연결된 계정을 회원 탈퇴했습니다.")
+
+                                viewModel.deleteUser()
+
+                                navController.navigate(SignInNav.SignIn.route) {
+                                    popUpTo(navController.graph.id) {
+                                        inclusive = true
+                                    }
+                                    launchSingleTop = true
+                                }
+
+                                viewModel.removeToken()
+                            }
+                        }
+                    },
                     "회원 탈퇴하시겠습니까?",
                     isDarkTheme
                 )

--- a/src/mobile/vistiandroid/presentation/src/main/java/com/ssafy/presentation/ui/setting/UserAccountViewModel.kt
+++ b/src/mobile/vistiandroid/presentation/src/main/java/com/ssafy/presentation/ui/setting/UserAccountViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ssafy.domain.model.Resource
 import com.ssafy.domain.usecase.account.AccountUseCase
+import com.ssafy.domain.usecase.account.DeleteUserUseCase
 import com.ssafy.presentation.ui.story.StoryState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,10 +17,14 @@ import javax.inject.Inject
 @HiltViewModel
 class UserAccountViewModel @Inject constructor(
     private val accountUseCase: AccountUseCase,
+    private val deleteUserUseCase: DeleteUserUseCase
 ) : ViewModel() {
 
     private val _accessToken = MutableStateFlow<StoryState>(StoryState())
     val accessToken: StateFlow<StoryState> = _accessToken.asStateFlow()
+
+    private val _deleteUser = MutableStateFlow<StoryState>(StoryState())
+    val deleteUser: StateFlow<StoryState> = _deleteUser.asStateFlow()
 
     fun removeToken() {
         accountUseCase().onEach { result ->
@@ -34,6 +39,24 @@ class UserAccountViewModel @Inject constructor(
 
                 is Resource.Loading -> {
                     _accessToken.value = StoryState(isLoading = true)
+                }
+            }
+        }.launchIn(viewModelScope)
+    }
+
+    fun deleteUser() {
+        deleteUserUseCase().onEach { result ->
+            when (result) {
+                is Resource.Success -> {
+                    _deleteUser.value = StoryState(accessToken = result.data ?: "")
+                }
+
+                is Resource.Error -> {
+                    _deleteUser.value = StoryState(error = result.message ?: "An error occurred")
+                }
+
+                is Resource.Loading -> {
+                    _deleteUser.value = StoryState(isLoading = true)
                 }
             }
         }.launchIn(viewModelScope)


### PR DESCRIPTION
## Summary
카카오 계정의 유저의 회원탈퇴 기능

## Describe your changes
```
onConfirmation = {
    signOutState.value = false

    UserApiClient.instance.unlink { error ->
        if (error != null) {
            // 에러가 발생한 경우 처리
            Log.d("ohhuiju", "회원 탈퇴 실패: $error")
        } else {
            // 회원 탈퇴가 성공한 경우 처리
            Log.d("ohhuiju","카카오 소셜 로그인으로 연결된 계정을 회원 탈퇴했습니다.")

            viewModel.deleteUser()

            navController.navigate(SignInNav.SignIn.route) {
                popUpTo(navController.graph.id) {
                    inclusive = true
                }
                launchSingleTop = true
            }

            viewModel.removeToken()
        }
    }
}
```
